### PR TITLE
Add generic gitmodules for wildmidi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "wildmidi"]
+    path = wildmidi
+    url = https://github.com/Mindwerks/wildmidi
+    branch = master


### PR DESCRIPTION
This should hopefully resolve the build errors happening because the wildmidi submodule is not correctly configured. I don't know if the submodule is necessary for it to run and build correctly, but adding this should allow the submodule to be cloned as part of the build process. It's possible the entire submodule could be removed at a later date.